### PR TITLE
Remove diagnostics and add warnings

### DIFF
--- a/lib/Bio/RNA/RNAaliSplit.pm
+++ b/lib/Bio/RNA/RNAaliSplit.pm
@@ -16,7 +16,7 @@ use IPC::Cmd qw(can_run run);
 #use Bio::AlignIO;
 use Storable 'dclone';
 use File::Path qw(make_path);
-use diagnostics;
+use warnings;
 
 extends 'Bio::RNA::RNAaliSplit::AliHandler';
 

--- a/lib/Bio/RNA/RNAaliSplit/AliFeature.pm
+++ b/lib/Bio/RNA/RNAaliSplit/AliFeature.pm
@@ -9,7 +9,7 @@ package Bio::RNA::RNAaliSplit::AliFeature;
 use Moose;
 use namespace::autoclean;
 use version; our $VERSION = qv('0.11');
-use diagnostics;
+use warnings;
 use Data::Dumper;
 use Carp;
 

--- a/lib/Bio/RNA/RNAaliSplit/AliHandler.pm
+++ b/lib/Bio/RNA/RNAaliSplit/AliHandler.pm
@@ -9,7 +9,7 @@ use Moose;
 use Bio::RNA::RNAaliSplit::Subtypes;
 use namespace::autoclean;
 use Data::Dumper;
-use diagnostics;
+use warnings;
 use version; our $VERSION = qv('0.11');
 
 has 'format' => (

--- a/scripts/RNAalisplit.pl
+++ b/scripts/RNAalisplit.pl
@@ -22,7 +22,6 @@ use Path::Class;
 use File::Basename;
 use Carp;
 use RNA;
-use diagnostics;
 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#
 #^^^^^^^^^^ Variables ^^^^^^^^^^^#

--- a/scripts/eval_alignment.pl
+++ b/scripts/eval_alignment.pl
@@ -33,7 +33,6 @@ my $nofigures = 0;
 my $outdir = "eval_result";
 my $stat = "GTp";
 my $have_logfile=0;
-use diagnostics;
 
 Getopt::Long::config('no_ignore_case');
 pod2usage(-verbose => 1) unless


### PR DESCRIPTION
## Summary
- drop `use diagnostics` from modules and scripts
- ensure warnings are enabled in modules

## Testing
- `prove -lr t` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686cfdab4b24832da0fdc10f1560072b