### PR TITLE
Fix subdirectory creation errors

### DIFF
--- a/lib/Bio/RNA/RNAaliSplit.pm
+++ b/lib/Bio/RNA/RNAaliSplit.pm
@@ -76,7 +76,9 @@ sub BUILD {
 
     # dump ifile as aln and stk in ClustalW format to odir/input
     my $iodir = $self->odir->subdir('input');
-    mkdir($iodir);
+    my @created = make_path($iodir, {error => \my $err});
+    croak "ERROR [$this_function] could not create output directory $iodir"
+      if (@$err);
     my $ialnfile = file($iodir,$self->ifilebn.".aln");
     my $istkfile = file($iodir,$self->ifilebn.".stk");
     my $alnio = Bio::AlignIO->new(-file   => ">$ialnfile",
@@ -110,7 +112,9 @@ sub dump_subalignment {
   my $ids = join "_", @$what;
   unless (defined($alipathsegment)){$alipathsegment = "tmp"}
   my $oodir = $self->odir->subdir($alipathsegment);
-  mkdir($oodir);
+  my @created = make_path($oodir, {error => \my $err});
+  croak "ERROR [$this_function] could not create output directory $oodir"
+    if (@$err);
 
   # create info file
   my $oinfofile = file($oodir,$token.".info");


### PR DESCRIPTION
## Summary
- ensure `make_path` is used when creating `input` and temporary output directories
- croak with a helpful message if directory creation fails

## Testing
- `perl Makefile.PL`
- `make test` *(fails: Can't locate Test2/V0.pm)*

------
https://chatgpt.com/codex/tasks/task_e_686cff85ae78832dad83279e79d25d79