### PR TITLE
Improve dependency checks in t/00-load.t

### DIFF
--- a/t/00-load.t
+++ b/t/00-load.t
@@ -2,12 +2,13 @@
 use Test2::V0;
 use IPC::Cmd qw(can_run);
 
+my @required = qw(AnalyseDists RNAalifold RNAz R-scape);
+my @missing  = grep { !can_run($_) } @required;
+
+BAIL_OUT('Missing required external tools: ' . join(', ', @missing))
+    if @missing;
+
 use ok 'RNA';
 diag( "Testing Vienna RNA $RNA::VERSION, Perl $], $^X" );
-
-ok( defined(can_run('AnalyseDists')), 'Bail out! AnalyseDists not found');
-ok( defined(can_run('RNAalifold')), 'Bail out! RNAalifold not found');
-ok( defined(can_run('RNAz')), 'Bail out! RNAz not found');
-ok( defined(can_run('R-scape')), 'Bail out! R-scape not found');
 
 done_testing;


### PR DESCRIPTION
## Summary
- exit the entire test run when required external tools are absent

## Testing
- `prove -lr t` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d100246b8832da11cbe0608bd3e1e